### PR TITLE
Add multilingual support for Spanish and English languages

### DIFF
--- a/data/templates/chose_en.txt
+++ b/data/templates/chose_en.txt
@@ -1,0 +1,3 @@
+You chose the Ibex35 stock: <b>{}</b>
+
+🔎 Checking alive short positions...

--- a/data/templates/chose_es.txt
+++ b/data/templates/chose_es.txt
@@ -1,0 +1,3 @@
+Has seleccionado la empresa del Ibex35: <b>{}</b>
+
+🔎 Comprobando si existe alguna posición en corto...

--- a/data/templates/help_en.txt
+++ b/data/templates/help_en.txt
@@ -1,0 +1,12 @@
+⤵️ <b>ShortBot</b> checks whether a value of the Ibex35 has an alive short position against it.
+
+The information is retrieved from CNMV's web page.
+
+🤳 For a given stock, the bot checks if there's any ✓ open short position at the moment, and sums up 𝚺 the size of all the active short positions against the stock.
+
+Moreover, it is detailed a full list of all the individual short positions, including the % of the position compared to the capital of the company, and the date at which the position was notified to the regulator.
+
+🔎 Updates to the regulator are given once per day, thus open positions won't change
+until the next day (at least).
+
+👨‍🔧 This bot is under development, and new features will be released soon! If you find a bug, or you'd like to propose a new feature, please subscribe to the @ibexshortbot_channel channel in Telegram.

--- a/data/templates/help_es.txt
+++ b/data/templates/help_es.txt
@@ -1,0 +1,11 @@
+⤵️ <b>ShortBot</b> permite comprobar si un valor del Ibex35 tiene posiciones en corto  abiertas actualmente.
+
+La información se obtiene de la página web de la CNMV.
+
+🤳 Para cada valor, se comprueba si hay posiciones abiertas ✓ en el momento actual, y se realiza una sumatoria 𝚺 de todas las posiciones en corto abiertas.
+
+Además, se ofrece un listado con los nombres de los fondos que tienen abiertas dichas posiciones, así como el % de la posición sobre el capital social total y la fecha en que se notificó dicha posición al regulador.
+
+🔎 Las actualizaciones al regulador se realizan una vez al día, por lo que los valores reportados no cambiaran, como mínimo, hasta el día siguiente.
+
+👨‍🔧 El bot se encuentra en desarrollo, y ¡pronto aparecerán nuevas funcionalidades! Si encuentras un problema, o quieres proponer alguna funcionalidad nueva, ¡suscríbete al canal de Telegram @ibexshortbot_channel!

--- a/data/templates/short_position_brief.txt
+++ b/data/templates/short_position_brief.txt
@@ -1,2 +1,0 @@
-𝚺 The position weight is: <b>{:.2} %</b>
-{}

--- a/data/templates/short_position_en.txt
+++ b/data/templates/short_position_en.txt
@@ -1,0 +1,1 @@
+𝚺 The position weight is: <b>{:.2} %</b>

--- a/data/templates/short_position_es.txt
+++ b/data/templates/short_position_es.txt
@@ -1,0 +1,1 @@
+𝚺 El total de la posición corta es: <b>{:.2} %</b>

--- a/data/templates/welcome_en.txt
+++ b/data/templates/welcome_en.txt
@@ -1,0 +1,4 @@
+Welcome {} to the Ibex35 ShortBot 🕵️!
+
+This bot simplifies checking if a stock has ⤵️ short positions against it at the moment.
+To start up, just type /short or check the bot's help using /help.

--- a/data/templates/welcome_es.txt
+++ b/data/templates/welcome_es.txt
@@ -1,0 +1,5 @@
+¡Bienvenido {} al Ibex35 ShortBot 🕵️!
+
+Este bot permite comprobar de manera fácil si un valor del Ibex35 tiene alguna ⤵️ posición en corto abierta en el momento de la comprobación.
+
+Para comenzar rápidamente, simplemente usa el comando /short o comprueba la ayuda usando /ayuda.

--- a/src/endpoints/help.rs
+++ b/src/endpoints/help.rs
@@ -1,21 +1,57 @@
 //! Handler for the /help command.
 
-use crate::{CommandEng, HandlerResult};
-use teloxide::{prelude::*, utils::command::BotCommands};
-use tracing::info;
+use crate::{CommandEng, CommandSpa, HandlerResult};
+use teloxide::{prelude::*, types::ParseMode, utils::command::BotCommands};
+use tracing::{debug, info};
 
 /// Help handler.
 #[tracing::instrument(
     name = "Help handler",
-    skip(bot, msg),
+    skip(bot, msg, update),
     fields(
         chat_id = %msg.chat.id,
     )
 )]
-pub async fn help(bot: Bot, msg: Message) -> HandlerResult {
+pub async fn help(bot: Bot, msg: Message, update: Update) -> HandlerResult {
     info!("Command /help requested");
-    bot.send_message(msg.chat.id, CommandEng::descriptions().to_string())
+
+    // First, try to retrieve the user of the chat.
+    let lang_code = match update.user() {
+        Some(user) => user.language_code.clone(),
+        None => None,
+    };
+
+    debug!("The user's language code is: {:?}", lang_code);
+
+    let message = match lang_code {
+        Some(lang_code) => match lang_code.as_str() {
+            "es" => _help_es(),
+            _ => _help_en(),
+        },
+        _ => _help_en(),
+    };
+
+    bot.send_message(msg.chat.id, message)
+        .parse_mode(ParseMode::Html)
         .await?;
 
     Ok(())
+}
+
+/// Help handler (English version).
+fn _help_en() -> String {
+    format!(
+        "{}\n\n⚙️{}",
+        include_str!("../../data/templates/help_en.txt"),
+        CommandEng::descriptions(),
+    )
+}
+
+/// Help handler (Spanish version).
+fn _help_es() -> String {
+    format!(
+        "{}\n\n⚙️{}",
+        include_str!("../../data/templates/help_es.txt"),
+        CommandSpa::descriptions(),
+    )
 }

--- a/src/endpoints/receivestock.rs
+++ b/src/endpoints/receivestock.rs
@@ -36,6 +36,9 @@ pub async fn receive_stock(
         bot.send_message(dialogue.chat_id(), "No stock given")
             .await?;
         info!("No valid ticker was received");
+        info!("Short position request served");
+        dialogue.exit().await?;
+        return Ok(())
     }
 
     let provider = CNMVProvider::new();

--- a/src/handlers/schema.rs
+++ b/src/handlers/schema.rs
@@ -7,7 +7,7 @@
 //! All valid combinations of Messages and States shall be contemplated in the implementation
 //! of this handler.
 
-use crate::{endpoints::*, CommandEng, State};
+use crate::{endpoints::*, CommandEng, CommandSpa, State};
 use teloxide::{
     dispatching::{dialogue, dialogue::InMemStorage, UpdateHandler},
     prelude::*,
@@ -17,15 +17,23 @@ use teloxide::{
 pub fn schema() -> UpdateHandler<Box<dyn std::error::Error + Send + Sync + 'static>> {
     use dptree::case;
 
-    let command_handler = teloxide::filter_command::<CommandEng, _>().branch(
+    let command_handler_eng = teloxide::filter_command::<CommandEng, _>().branch(
         case![State::Start]
             .branch(case![CommandEng::Start].endpoint(start))
             .branch(case![CommandEng::Help].endpoint(help))
-            .branch(case![CommandEng::ChooseStock].endpoint(list_stocks)),
+            .branch(case![CommandEng::Short].endpoint(list_stocks)),
+    );
+
+    let command_handler_spa = teloxide::filter_command::<CommandSpa, _>().branch(
+        case![State::Start]
+            .branch(case![CommandSpa::Inicio].endpoint(start))
+            .branch(case![CommandSpa::Ayuda].endpoint(help))
+            .branch(case![CommandSpa::Short].endpoint(list_stocks)),
     );
 
     let message_handler = Update::filter_message()
-        .branch(command_handler)
+        .branch(command_handler_eng)
+        .branch(command_handler_spa)
         .branch(case![State::ListStocks].endpoint(list_stocks));
 
     let query_handler =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,23 +48,34 @@ pub enum State {
     ReceiveStock,
 }
 
-/// Application commands in English language
-///
-/// # Description
-///
-/// TODO! document the commands.
+/// User commands in English language
 #[derive(BotCommands, Clone)]
 #[command(
-    rename_rule = "lowercase",
+    rename_rule = "camelCase",
     description = "These commands are supported by the Bot:"
 )]
 pub enum CommandEng {
-    #[command(description = "Start a new session.")]
+    #[command(description = "Start a new session")]
     Start,
-    #[command(description = "Display this message.")]
+    #[command(description = "Display help message")]
     Help,
-    #[command(description = "List available stocks.")]
-    ChooseStock,
+    #[command(description = "Check short position of a stock")]
+    Short,
+}
+
+/// User commands in Spanish language
+#[derive(BotCommands, Clone)]
+#[command(
+    rename_rule = "camelCase",
+    description = "Estos son los comandos soportados por el Bot:"
+)]
+pub enum CommandSpa {
+    #[command(description = "Iniciar una nueva sesión")]
+    Inicio,
+    #[command(description = "Mostrar la ayuda")]
+    Ayuda,
+    #[command(description = "Consultar posiciones de una acción")]
+    Short,
 }
 
 /// Finance module.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,13 @@ use shortbot::{
     telemetry::{get_subscriber, init_subscriber},
     State, IBEX35_STOCK_DESCRIPTORS,
 };
+use shortbot::{CommandEng, CommandSpa};
 use std::sync::Arc;
 use teloxide::dispatching::dialogue::InMemStorage;
+use teloxide::payloads::SetMyCommandsSetters;
 use teloxide::prelude::*;
-use tracing::info;
+use teloxide::utils::command::BotCommands;
+use tracing::{debug, info};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -31,6 +34,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Started ShortBot server");
 
     let bot = Bot::new(settings.application.api_token.expose_secret());
+
+    // Configure the supported languages of the Bot.
+    debug!("Setting up commands of the bot");
+    bot.set_my_commands(CommandSpa::bot_commands())
+        .language_code("es")
+        .await?;
+    bot.set_my_commands(CommandEng::bot_commands())
+        .language_code("en")
+        .await?;
 
     info!("Dispatching");
 


### PR DESCRIPTION
This feature adds the possibility of using the bot in Spanish and English (default lang for non-English speakers). The language is selected automatically using the language code provided by Telegram (set by the app).

All the existing endpoints include messages in both languages, and the main message handler has been modified to filter Spanish commands as well. Nothing new was added, this feature just allows using the same client features in Spanish.